### PR TITLE
removing unneeded slf4j-simple from POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,11 +168,11 @@
             <artifactId>hamcrest-core</artifactId>
             <scope>test</scope>
         </dependency>
-      <!--  <dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
-        </dependency> -->
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
I commented out two slf4j-simple statements from the POM file that were leading to an annoying warning message -- we only need one implementation. Please delete these and merge.